### PR TITLE
add: Makefile support for 'build' and 'clean'

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,6 +15,12 @@ PORT          = 8000
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
 
+clean:
+	rm -rf html source/_build
+
+build:
+	cd $(SOURCEDIR) && python -m sphinx -T -b html -d _build/doctrees -D language=zh . ../html
+
 server:
 	cd $(BUILDDIR)/html && python -m http.server $(PORT)
 


### PR DESCRIPTION
## 支持 docs 目录下的文档编译

- make build 编译文档，命令与 readthedocs 的配置相同
- make clean 清理已编译的文档

