### PR TITLE
fix(model.py): align_preciion_in_norm_layer

### DIFF
--- a/collie/models/base.py
+++ b/collie/models/base.py
@@ -337,7 +337,10 @@ class CollieModelForCausalLM(nn.Module, GenerationMixin):
                             if name in state_dict:
                                 assert param.data.shape == state_dict[name].data.shape, f"The shape of the parameter corresponding to the `{name}` does not match: {param.data.shape} vs {state_dict[name].data.shape}"
                             param.data = value.to(param.device)
-            
+        
+        for name, layer in model.named_modules():
+            if hasattr(layer, 'set_norm_precision_to_float32'):
+                layer.set_norm_precision_to_float32()    
         
         if config.peft_config.peft_type is not None:
             model = get_peft_model(model, config.peft_config)

--- a/collie/models/internlm/model.py
+++ b/collie/models/internlm/model.py
@@ -80,6 +80,9 @@ class RMSNormalize(nn.Module):
             )
         self.eps = eps
 
+    def set_norm_precision_to_float32(self):
+        self.weight.data = self.weight.data.to(torch.float32) 
+
     def forward(self, hidden_states):
         variance = hidden_states.to(torch.float32).pow(2).mean(-1, keepdim=True)
         hidden_states = hidden_states * torch.rsqrt(variance + self.eps)

--- a/collie/models/internlm2/model.py
+++ b/collie/models/internlm2/model.py
@@ -122,6 +122,9 @@ class InternLM2RMSNorm(nn.Module):
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
 
+    def set_norm_precision_to_float32(self):
+        self.weight.data = self.weight.data.to(torch.float32) 
+
     def forward(self, hidden_states):
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)

--- a/collie/models/llama/model.py
+++ b/collie/models/llama/model.py
@@ -80,6 +80,9 @@ class RMSNormalize(nn.Module):
             )
         self.eps = eps
 
+    def set_norm_precision_to_float32(self):
+        self.weight.data = self.weight.data.to(torch.float32) 
+
     def forward(self, hidden_states):
         variance = hidden_states.to(torch.float32).pow(2).mean(-1, keepdim=True)
         hidden_states = hidden_states * torch.rsqrt(variance + self.eps)

--- a/collie/models/moss/model.py
+++ b/collie/models/moss/model.py
@@ -80,6 +80,9 @@ class RMSNormalize(nn.Module):
             )
         self.eps = eps
 
+    def set_norm_precision_to_float32(self):
+        self.weight.data = self.weight.data.to(torch.float32) 
+
     def forward(self, hidden_states):
         variance = hidden_states.to(torch.float32).pow(2).mean(-1, keepdim=True)
         hidden_states = hidden_states * torch.rsqrt(variance + self.eps)

--- a/collie/models/moss_moon/model.py
+++ b/collie/models/moss_moon/model.py
@@ -271,6 +271,10 @@ class MossBlock(nn.Module):
         self.use_cache = False
         self.hidden_states = None
 
+    def set_norm_precision_to_float32(self):
+        self.ln_1.weight.data = self.ln_1.weight.data.to(torch.float32) 
+        self.ln_1.bias.data   = self.ln_1.bias.data.to(torch.float32) 
+
     def _forward(
         self,
         hidden_states: Optional[torch.FloatTensor],
@@ -393,6 +397,10 @@ class Moss003MoonModel(nn.Module):
         self.drop = nn.Dropout(config.embd_pdrop)
         self.h = nn.ModuleList([MossBlock(config, i) for i in range(config.n_layer)])
         self.ln_f = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_epsilon)
+
+    def set_norm_precision_to_float32(self):
+        self.ln_f.weight.data = self.ln_f.weight.data.to(torch.float32) 
+        self.ln_f.bias.data   = self.ln_f.bias.data.to(torch.float32) 
 
     def forward(
         self,


### PR DESCRIPTION
在 Norm Layer 中添加 set_norm_precision_to_float32 函数，在 model 初始化后调用，将 Norm Layer 的权重转成 float32